### PR TITLE
Implement Product Pagination and Query

### DIFF
--- a/index.py
+++ b/index.py
@@ -27,7 +27,7 @@ api = Api(app)
 # Product routes
 api.add_resource(Product, "/api/product/<string:product_id>", endpoint="product_by_id")
 api.add_resource(Product, "/api/product", endpoint="product")
-api.add_resource(Products, "/api/products")
+api.add_resource(Products, "/api/products", endpoint="products")
 
 
 @app.route("/", methods=["POST", "GET"])

--- a/models/Product.py
+++ b/models/Product.py
@@ -1,5 +1,4 @@
 """Product Model"""
-from bson.objectid import ObjectId
 from mongoengine.base.fields import ObjectIdField
 from mongoengine.document import Document
 from mongoengine.fields import (
@@ -14,7 +13,7 @@ from mongoengine.fields import (
 class Item(EmbeddedDocument):
     """Item Schema"""
 
-    _id = ObjectIdField(default=ObjectId())
+    _id = ObjectIdField()
     title = StringField(max_length=75, required=True)
     description = StringField(max_length=250, required=True)
     price = DecimalField(min_value=0, required=True)
@@ -25,7 +24,7 @@ class Item(EmbeddedDocument):
 class Product(Document):
     """Product Schema"""
 
-    _id = ObjectIdField(default=ObjectId())
+    _id = ObjectIdField()
     title = StringField(max_length=75, required=True)
     description = StringField(max_length=250, required=True)
     price = DecimalField(min_value=0, precision=2, required=True)

--- a/product.py
+++ b/product.py
@@ -1,7 +1,7 @@
 # pylint: disable=no-member
 
 """CRUD REST-API For Product"""
-from flask_restful import Resource, reqparse, abort
+from flask_restful import Resource, reqparse, abort, request
 from mongoengine import ValidationError
 from models.Product import Product as product_model
 
@@ -45,7 +45,8 @@ class Product(Resource):
         product = product_args.parse_args()
         new_product = product_model(**product)
         try:
-            new_product.save()
+            saved = new_product.save()
+            print(saved)
         except ValidationError:
             abort(400, message="Error creating product document")
         return 201
@@ -87,6 +88,31 @@ class Products(Resource):
 
     @staticmethod
     def get():
-        """Handles the get request and returns all the products in the collection"""
-        products = product_model.objects.all()
-        return products.to_json(), 200
+        """Handles the get request and returns multiple products in the collection"""
+
+        # Handles the search query and pagination
+        query = request.args.get("q")
+        page_number = request.args.get("page")
+
+        # if no page number is provided then get all the product from the DB
+        if page_number is not None:
+            # if search query is specified then find product titles that contain that query
+            if query is not None:
+                # offset helps determine which product object to start with when paginating
+                pagination_limit = 15
+                offset = (int(page_number) - 1) * pagination_limit
+                # Objects are filtered by whether the title contains(case-insensitive) the query
+                paginated_products = (
+                    product_model.objects(title__icontains=query)
+                    .skip(offset)
+                    .limit(pagination_limit)
+                )
+                return paginated_products.to_json(), 200
+            # if search query is not provided then just paginate all the product objects
+            else:
+                offset = (int(page_number) - 1) * 15
+                paginated_products = product_model.objects.skip(offset).limit(15)
+                return paginated_products.to_json(), 200
+        else:
+            products = product_model.objects.all()
+            return products.to_json(), 200

--- a/product.py
+++ b/product.py
@@ -45,8 +45,7 @@ class Product(Resource):
         product = product_args.parse_args()
         new_product = product_model(**product)
         try:
-            saved = new_product.save()
-            print(saved)
+            new_product.save()
         except ValidationError:
             abort(400, message="Error creating product document")
         return 201

--- a/product.py
+++ b/product.py
@@ -107,12 +107,10 @@ class Products(Resource):
                     .skip(offset)
                     .limit(pagination_limit)
                 )
-                return paginated_products.to_json(), 200
             # if search query is not provided then just paginate all the product objects
             else:
                 offset = (int(page_number) - 1) * 15
                 paginated_products = product_model.objects.skip(offset).limit(15)
-                return paginated_products.to_json(), 200
-        else:
-            products = product_model.objects.all()
-            return products.to_json(), 200
+            return paginated_products.to_json(), 200
+        products = product_model.objects.all()
+        return products.to_json(), 200

--- a/product.py
+++ b/product.py
@@ -99,18 +99,21 @@ class Products(Resource):
             # if search query is specified then find product titles that contain that query
             if query is not None:
                 # offset helps determine which product object to start with when paginating
-                pagination_limit = 15
-                offset = (int(page_number) - 1) * pagination_limit
+                product_limit = 15
+                offset = (int(page_number) - 1) * product_limit
                 # Objects are filtered by whether the title contains(case-insensitive) the query
                 paginated_products = (
                     product_model.objects(title__icontains=query)
                     .skip(offset)
-                    .limit(pagination_limit)
+                    .limit(product_limit)
                 )
             # if search query is not provided then just paginate all the product objects
             else:
+                product_limit = 15
                 offset = (int(page_number) - 1) * 15
-                paginated_products = product_model.objects.skip(offset).limit(15)
+                paginated_products = product_model.objects.skip(offset).limit(
+                    product_limit
+                )
             return paginated_products.to_json(), 200
         products = product_model.objects.all()
         return products.to_json(), 200


### PR DESCRIPTION
- Implemented pagination for all products(/api/products?page=<page_number>) and also when querying products(/api/products?page=<page_number>&q=<query>)
- Number of products per page is currently set to 15
- Removed default parameter for ObjectIdField because it there was an issue with posting new consecutive documents cause it would overwrite the previous product object in DB
- Updated and added endpoint to the /api/products route